### PR TITLE
fix: dark mode support and quiz re-submission

### DIFF
--- a/d3/observablehq.config.js
+++ b/d3/observablehq.config.js
@@ -21,8 +21,11 @@ export default {
 .quiz-btn:hover { opacity: 0.85; }
 .quiz-feedback { margin-top: 0.6rem; font-weight: bold; font-size: 0.9rem; min-height: 1.2em; }
 .warning-box {
-  background: #fff3cd; border-left: 4px solid #e6a817;
+  background: #fff3cd; color: #1a1a1a; border-left: 4px solid #e6a817;
   padding: 0.75rem 1rem; margin: 1rem 0; border-radius: 4px; font-size: 0.9rem;
+}
+@media (prefers-color-scheme: dark) {
+  .warning-box { background: #2a2000; color: #f0e6b0; }
 }
 .tip-box {
   background: var(--theme-background-alt); border-left: 4px solid #4e79a7;

--- a/d3/src/components/parallelCoordinates.js
+++ b/d3/src/components/parallelCoordinates.js
@@ -110,7 +110,7 @@ export function parallelCoordinates(data, {
       .attr("text-anchor", "middle")
       .style("font-size", "11px")
       .style("font-weight", "bold")
-      .attr("fill", "#333")
+      .attr("fill", "currentColor")
       .text(NUMERIC_LABELS[v] || v);
   });
 
@@ -125,6 +125,7 @@ export function parallelCoordinates(data, {
         .attr("stroke", regionColor(r)).attr("stroke-width", 2.5);
       lg.append("text")
         .attr("x", i * 110 + 20).attr("y", 10)
+        .attr("fill", "currentColor")
         .style("font-size", "10px").text(r);
     });
   }

--- a/d3/src/components/quiz.js
+++ b/d3/src/components/quiz.js
@@ -51,13 +51,15 @@ export function createQuiz({
     const isCorrect = answers[idx].correct === true;
     feedback.textContent = isCorrect ? correctFeedback : incorrectFeedback;
     feedback.style.color = isCorrect ? "#2e7d32" : "#c0392b";
-    form.querySelectorAll("label").forEach((lbl, i) => {
-      if (answers[i].correct) {
-        lbl.style.fontWeight = "bold";
-        lbl.style.color = "#2e7d32";
-      }
-    });
-    btn.disabled = true;
+    if (isCorrect) {
+      form.querySelectorAll("label").forEach((lbl, i) => {
+        if (answers[i].correct) {
+          lbl.style.fontWeight = "bold";
+          lbl.style.color = "#2e7d32";
+        }
+      });
+      btn.disabled = true;
+    }
   });
 
   form.appendChild(btn);

--- a/d3/src/components/scatterplotMatrix.js
+++ b/d3/src/components/scatterplotMatrix.js
@@ -35,6 +35,10 @@ function pearsonR(xs, ys) {
  *   colorByRegion  – color dots by region (default: false)
  *   cellSize       – pixels per cell (default: 130)
  */
+function isDark() {
+  return typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+}
+
 export function scatterplotMatrix(data, {
   variables = NUMERIC_VARS,
   colorByRegion = false,
@@ -73,10 +77,13 @@ export function scatterplotMatrix(data, {
         .attr("transform", `translate(${cx},${cy})`);
 
       // Cell background
+      const dark = isDark();
       cell.append("rect")
         .attr("width", cellSize).attr("height", cellSize)
-        .attr("fill", row === col ? "#f0f4f8" : "#fafafa")
-        .attr("stroke", "#ddd").attr("stroke-width", 0.5);
+        .attr("fill", row === col
+          ? (dark ? "#1a2433" : "#f0f4f8")
+          : (dark ? "#111820" : "#fafafa"))
+        .attr("stroke", dark ? "#2a3a4a" : "#ddd").attr("stroke-width", 0.5);
 
       if (row === col) {
         // Diagonal: histogram of this variable
@@ -174,27 +181,10 @@ export function scatterplotMatrix(data, {
       .attr("text-anchor", "middle")
       .style("font-size", "10px")
       .style("font-weight", "bold")
-      .attr("fill", "#333")
+      .attr("fill", "currentColor")
       .text(NUMERIC_LABELS[variables[row]] || variables[row]);
   });
 
-  // Outer labels
-  variables.forEach((v, i) => {
-    const pos = i * cellSize + cellSize / 2;
-    // Top labels (column variable)
-    svg.append("text")
-      .attr("x", labelH + pos).attr("y", 14)
-      .attr("text-anchor", "middle")
-      .style("font-size", "9px").attr("fill", "#555")
-      .text(NUMERIC_LABELS[v] || v);
-    // Left labels (row variable)
-    svg.append("text")
-      .attr("transform", `rotate(-90)`)
-      .attr("x", -(labelH + pos)).attr("y", 12)
-      .attr("text-anchor", "middle")
-      .style("font-size", "9px").attr("fill", "#555")
-      .text(NUMERIC_LABELS[v] || v);
-  });
 
   return svg.node();
 }

--- a/d3/src/style.css
+++ b/d3/src/style.css
@@ -60,16 +60,30 @@ svg {
 
 .axis text {
   font-size: 11px;
+  fill: currentColor;
+}
+
+.axis line,
+.axis path {
+  stroke: currentColor;
 }
 
 /* Misuse warning box */
 .warning-box {
   background: #fff3cd;
+  color: #1a1a1a;
   border-left: 4px solid #e6a817;
   padding: 0.75rem 1rem;
   margin: 1rem 0;
   border-radius: 4px;
   font-size: 0.9rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .warning-box {
+    background: #2a2000;
+    color: #f0e6b0;
+  }
 }
 
 /* Callout / tip box */


### PR DESCRIPTION
- Allow re-checking answer after incorrect quiz submission (button was incorrectly disabled on wrong answers)
- Warning boxes now adapt to dark/light mode instead of hardcoded yellow
- SPLOM cell backgrounds adapt to dark mode; remove overlapping outer axis labels (diagonal labels already identify each variable)
- Use currentColor for all SVG text in SPLOM and parallel coordinates so labels remain readable in both themes
- Add fill/stroke: currentColor to .axis CSS rule for D3 tick text