### PR TITLE
fix: dark/light mode polish, SPLOM improvements, chart fixes

### DIFF
--- a/d3/observablehq.config.js
+++ b/d3/observablehq.config.js
@@ -32,7 +32,13 @@ export default {
   padding: 0.75rem 1rem; margin: 1rem 0; border-radius: 4px; font-size: 0.9rem;
 }
 svg { max-width: 100%; height: auto; overflow: visible; }
-.chart-x-label, .chart-y-label { font-size: 12px; fill: var(--theme-foreground-muted, #666); }
+.splom-cell-diag { fill: #f0f4f8; }
+.splom-cell-off  { fill: #fafafa; }
+@media (prefers-color-scheme: dark) {
+  .splom-cell-diag { fill: #1a2433; }
+  .splom-cell-off  { fill: #111820; }
+}
+.chart-x-label, .chart-y-label { font-size: 12px; fill: currentColor; opacity: 0.75; }
 </style>`,
   pages: [
     { name: "Start",                 path: "/start" },

--- a/d3/src/components/boxplot.js
+++ b/d3/src/components/boxplot.js
@@ -46,7 +46,8 @@ export function boxplot(data, {
   width = 640,
   height = 420,
 } = {}) {
-  const margin = { top: 24, right: 30, bottom: 60, left: 70 };
+  const legendW = groupByRegion ? 110 : 0;
+  const margin = { top: 24, right: 30 + legendW, bottom: 60, left: 70 };
   const iw = width - margin.left - margin.right;
   const ih = height - margin.top - margin.bottom;
 
@@ -112,14 +113,14 @@ export function boxplot(data, {
       .attr("x1", cx).attr("x2", cx)
       .attr("y1", yScale(stats.whiskerLow))
       .attr("y2", yScale(stats.whiskerHigh))
-      .attr("stroke", "#444").attr("stroke-width", 1.5);
+      .attr("stroke", "currentColor").attr("stroke-width", 1.5);
 
     // Whisker caps
     [[stats.whiskerLow], [stats.whiskerHigh]].forEach(([w]) => {
       gc.append("line")
         .attr("x1", cx - bw * 0.25).attr("x2", cx + bw * 0.25)
         .attr("y1", yScale(w)).attr("y2", yScale(w))
-        .attr("stroke", "#444").attr("stroke-width", 1.5);
+        .attr("stroke", "currentColor").attr("stroke-width", 1.5);
     });
 
     // Box
@@ -130,7 +131,7 @@ export function boxplot(data, {
       .attr("height", yScale(stats.q1) - yScale(stats.q3))
       .attr("fill", fill)
       .attr("opacity", 0.75)
-      .attr("stroke", "#333")
+      .attr("stroke", "currentColor")
       .attr("stroke-width", 1);
 
     // Median line
@@ -148,7 +149,7 @@ export function boxplot(data, {
       .attr("cy", (d) => yScale(d._val))
       .attr("r", 3.5)
       .attr("fill", fill)
-      .attr("stroke", "#333")
+      .attr("stroke", "currentColor")
       .attr("stroke-width", 0.7)
       .attr("opacity", 0.8)
       .on("mouseover", (event, d) => {
@@ -170,7 +171,7 @@ export function boxplot(data, {
       legend.append("rect").attr("x", 0).attr("y", i * 18).attr("width", 12).attr("height", 12)
         .attr("fill", regionColor(key)).attr("opacity", 0.75);
       legend.append("text").attr("x", 16).attr("y", i * 18 + 10)
-        .style("font-size", "11px").text(key);
+        .attr("fill", "currentColor").style("font-size", "11px").text(key);
     });
   }
 

--- a/d3/src/components/histogram.js
+++ b/d3/src/components/histogram.js
@@ -28,16 +28,17 @@ function getTooltip() {
 export function histogram(data, {
   variable = "life_expectancy",
   bins = 10,
+  colorByRegion = false,
   width = 640,
   height = 400,
 } = {}) {
   return variable === "region"
     ? categoricalBar(data, { width, height })
-    : numericHistogram(data, { variable, bins, width, height });
+    : numericHistogram(data, { variable, bins, colorByRegion, width, height });
 }
 
-function numericHistogram(data, { variable, bins, width, height }) {
-  const margin = { top: 24, right: 20, bottom: 60, left: 60 };
+function numericHistogram(data, { variable, bins, colorByRegion, width, height }) {
+  const margin = { top: 24, right: colorByRegion ? 130 : 20, bottom: 60, left: 60 };
   const iw = width - margin.left - margin.right;
   const ih = height - margin.top - margin.bottom;
 
@@ -46,8 +47,10 @@ function numericHistogram(data, { variable, bins, width, height }) {
 
   const xScale = d3.scaleLinear().domain(d3.extent(values)).nice().range([0, iw]);
   const binner = d3.bin().value((d) => d[variable]).domain(xScale.domain()).thresholds(bins);
-  const binsData = binner(filtered);
-  const yScale = d3.scaleLinear().domain([0, d3.max(binsData, (b) => b.length)]).nice().range([ih, 0]);
+
+  // Y scale based on full dataset so all regions share the same axis
+  const allBins = binner(filtered);
+  const yScale = d3.scaleLinear().domain([0, d3.max(allBins, (b) => b.length)]).nice().range([ih, 0]);
 
   const svg = d3.create("svg")
     .attr("width", width).attr("height", height)
@@ -59,7 +62,6 @@ function numericHistogram(data, { variable, bins, width, height }) {
   g.append("g").attr("transform", `translate(0,${ih})`).call(d3.axisBottom(xScale).ticks(6));
   g.append("g").call(d3.axisLeft(yScale).ticks(6));
 
-  // Axis labels
   g.append("text").attr("class", "chart-x-label")
     .attr("x", iw / 2).attr("y", ih + 44)
     .attr("text-anchor", "middle")
@@ -73,25 +75,64 @@ function numericHistogram(data, { variable, bins, width, height }) {
 
   const tooltip = getTooltip();
 
-  g.selectAll("rect.bin")
-    .data(binsData)
-    .join("rect")
-    .attr("class", "bin")
-    .attr("x", (b) => xScale(b.x0) + 1)
-    .attr("y", (b) => yScale(b.length))
-    .attr("width", (b) => Math.max(0, xScale(b.x1) - xScale(b.x0) - 1))
-    .attr("height", (b) => ih - yScale(b.length))
-    .attr("fill", "#4e79a7")
-    .attr("opacity", 0.85)
-    .on("mouseover", (event, b) => {
-      tooltip.style.display = "block";
-      tooltip.innerHTML = `Range: ${d3.format(",.1f")(b.x0)} – ${d3.format(",.1f")(b.x1)}<br>Count: ${b.length}`;
-    })
-    .on("mousemove", (event) => {
-      tooltip.style.left = `${event.clientX + 14}px`;
-      tooltip.style.top = `${event.clientY - 36}px`;
-    })
-    .on("mouseout", () => { tooltip.style.display = "none"; });
+  if (colorByRegion) {
+    const cumulative = new Array(allBins.length).fill(0);
+    REGIONS.forEach((region) => {
+      const regionBins = binner(filtered.filter((d) => d.region === region));
+      regionBins.forEach((b, i) => {
+        if (b.length === 0) return;
+        const bottom = cumulative[i];
+        const top = bottom + b.length;
+        g.append("rect")
+          .attr("x", xScale(b.x0) + 1)
+          .attr("y", yScale(top))
+          .attr("width", Math.max(0, xScale(b.x1) - xScale(b.x0) - 1))
+          .attr("height", yScale(bottom) - yScale(top))
+          .attr("fill", regionColor(region))
+          .attr("opacity", 0.85)
+          .on("mouseover", (event) => {
+            tooltip.style.display = "block";
+            tooltip.innerHTML = `<strong>${region}</strong><br>Range: ${d3.format(",.1f")(b.x0)} – ${d3.format(",.1f")(b.x1)}<br>Count: ${b.length}`;
+          })
+          .on("mousemove", (event) => {
+            tooltip.style.left = `${event.clientX + 14}px`;
+            tooltip.style.top = `${event.clientY - 36}px`;
+          })
+          .on("mouseout", () => { tooltip.style.display = "none"; });
+        cumulative[i] = top;
+      });
+    });
+
+    // Legend
+    const lx = margin.left + iw + 10;
+    const lg = svg.append("g").attr("transform", `translate(${lx},${margin.top})`);
+    REGIONS.forEach((r, i) => {
+      lg.append("rect").attr("x", 0).attr("y", i * 20).attr("width", 12).attr("height", 12)
+        .attr("fill", regionColor(r)).attr("opacity", 0.7);
+      lg.append("text").attr("x", 16).attr("y", i * 20 + 10)
+        .attr("fill", "currentColor").style("font-size", "11px").text(r);
+    });
+  } else {
+    g.selectAll("rect.bin")
+      .data(allBins)
+      .join("rect")
+      .attr("class", "bin")
+      .attr("x", (b) => xScale(b.x0) + 1)
+      .attr("y", (b) => yScale(b.length))
+      .attr("width", (b) => Math.max(0, xScale(b.x1) - xScale(b.x0) - 1))
+      .attr("height", (b) => ih - yScale(b.length))
+      .attr("fill", "#4e79a7")
+      .attr("opacity", 0.85)
+      .on("mouseover", (event, b) => {
+        tooltip.style.display = "block";
+        tooltip.innerHTML = `Range: ${d3.format(",.1f")(b.x0)} – ${d3.format(",.1f")(b.x1)}<br>Count: ${b.length}`;
+      })
+      .on("mousemove", (event) => {
+        tooltip.style.left = `${event.clientX + 14}px`;
+        tooltip.style.top = `${event.clientY - 36}px`;
+      })
+      .on("mouseout", () => { tooltip.style.display = "none"; });
+  }
 
   return svg.node();
 }

--- a/d3/src/components/parallelCoordinates.js
+++ b/d3/src/components/parallelCoordinates.js
@@ -32,7 +32,7 @@ export function parallelCoordinates(data, {
   width = 900,
   height = 440,
 } = {}) {
-  const margin = { top: 48, right: 40, bottom: 24, left: 40 };
+  const margin = { top: 48, right: 40, bottom: colorByRegion ? 36 : 24, left: 40 };
   const iw = width - margin.left - margin.right;
   const ih = height - margin.top - margin.bottom;
 
@@ -75,7 +75,7 @@ export function parallelCoordinates(data, {
     .attr("stroke-width", 1.2)
     .attr("stroke-opacity", opacity)
     .on("mouseover", function(event, d) {
-      d3.select(this).raise()
+      d3.select(this)
         .attr("stroke-opacity", 1)
         .attr("stroke-width", 2.5);
       tooltip.style.display = "block";
@@ -114,17 +114,20 @@ export function parallelCoordinates(data, {
       .text(NUMERIC_LABELS[v] || v);
   });
 
-  // Region legend
+  // Region legend — centered below the chart
   if (colorByRegion) {
+    const itemW = 110;
+    const legendW = REGIONS.length * itemW;
+    const lx = (width - legendW) / 2;
     const lg = svg.append("g")
-      .attr("transform", `translate(${margin.left + iw - 90}, ${margin.top + ih + 4})`);
+      .attr("transform", `translate(${lx}, ${margin.top + ih + 8})`);
     REGIONS.forEach((r, i) => {
       lg.append("line")
-        .attr("x1", i * 110).attr("x2", i * 110 + 16)
+        .attr("x1", i * itemW).attr("x2", i * itemW + 16)
         .attr("y1", 6).attr("y2", 6)
         .attr("stroke", regionColor(r)).attr("stroke-width", 2.5);
       lg.append("text")
-        .attr("x", i * 110 + 20).attr("y", 10)
+        .attr("x", i * itemW + 20).attr("y", 10)
         .attr("fill", "currentColor")
         .style("font-size", "10px").text(r);
     });

--- a/d3/src/components/scatterplot.js
+++ b/d3/src/components/scatterplot.js
@@ -64,7 +64,7 @@ export function scatterplot(data, {
   // Grid lines
   g.append("g").attr("class", "grid")
     .call(d3.axisLeft(yScale).ticks(5).tickSize(-iw).tickFormat(""))
-    .selectAll("line").attr("stroke", "#eee");
+    .selectAll("line").attr("stroke", "currentColor").attr("stroke-opacity", "0.1");
   g.select(".grid .domain").remove();
 
   g.append("g").attr("transform", `translate(0,${ih})`)
@@ -119,7 +119,7 @@ export function scatterplot(data, {
       lg.append("circle").attr("cx", 6).attr("cy", i * 20 + 6).attr("r", 6)
         .attr("fill", regionColor(r)).attr("opacity", 0.8);
       lg.append("text").attr("x", 16).attr("y", i * 20 + 10)
-        .style("font-size", "11px").text(r);
+        .attr("fill", "currentColor").style("font-size", "11px").text(r);
     });
   }
 

--- a/d3/src/components/scatterplotMatrix.js
+++ b/d3/src/components/scatterplotMatrix.js
@@ -1,6 +1,6 @@
 import * as d3 from "npm:d3";
 import { NUMERIC_VARS, NUMERIC_LABELS, validFor, validForAll } from "./dataLoader.js";
-import { regionColor } from "./colors.js";
+import { regionColor, REGIONS } from "./colors.js";
 
 function getTooltip() {
   let tip = document.getElementById("mv-tooltip");
@@ -35,20 +35,17 @@ function pearsonR(xs, ys) {
  *   colorByRegion  – color dots by region (default: false)
  *   cellSize       – pixels per cell (default: 130)
  */
-function isDark() {
-  return typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches;
-}
-
 export function scatterplotMatrix(data, {
   variables = NUMERIC_VARS,
   colorByRegion = false,
-  cellSize = 130,
+  cellSize = 170,
 } = {}) {
   const n = variables.length;
   const pad = 2;
-  const labelH = 30;
+  const labelH = 60;
+  const legendW = colorByRegion ? 130 : 0;
   const totalSize = n * cellSize;
-  const width = totalSize + labelH * 2;
+  const width = totalSize + labelH * 2 + legendW;
   const height = totalSize + labelH * 2;
 
   // Pre-compute per-variable extents and scales
@@ -68,6 +65,28 @@ export function scatterplotMatrix(data, {
   const root = svg.append("g").attr("transform", `translate(${labelH},${labelH})`);
   const tooltip = getTooltip();
 
+  // Create outer axis labels first so cell hover can reference them
+  const topLabels = [];
+  const leftLabels = [];
+  variables.forEach((v, i) => {
+    const pos = i * cellSize + cellSize / 2;
+    topLabels.push(
+      svg.append("text")
+        .attr("x", labelH + pos).attr("y", labelH - 8)
+        .attr("text-anchor", "middle")
+        .style("font-size", "11px").attr("fill", "currentColor")
+        .text(NUMERIC_LABELS[v] || v)
+    );
+    leftLabels.push(
+      svg.append("text")
+        .attr("transform", "rotate(-90)")
+        .attr("x", -(labelH + pos)).attr("y", 14)
+        .attr("text-anchor", "middle")
+        .style("font-size", "11px").attr("fill", "currentColor")
+        .text(NUMERIC_LABELS[v] || v)
+    );
+  });
+
   variables.forEach((rowVar, row) => {
     variables.forEach((colVar, col) => {
       const cx = col * cellSize;
@@ -76,34 +95,59 @@ export function scatterplotMatrix(data, {
         .attr("class", `cell r${row}c${col}`)
         .attr("transform", `translate(${cx},${cy})`);
 
-      // Cell background
-      const dark = isDark();
+      // Cell background — fill via CSS class so it reacts to live theme changes
       cell.append("rect")
+        .attr("class", row === col ? "splom-cell-diag" : "splom-cell-off")
         .attr("width", cellSize).attr("height", cellSize)
-        .attr("fill", row === col
-          ? (dark ? "#1a2433" : "#f0f4f8")
-          : (dark ? "#111820" : "#fafafa"))
-        .attr("stroke", dark ? "#2a3a4a" : "#ddd").attr("stroke-width", 0.5);
+        .attr("stroke", "currentColor").attr("stroke-opacity", 0.15).attr("stroke-width", 0.5);
+
+      // Hover: subtly bold the relevant column (top) and row (left) axis labels
+      cell.on("mouseover", () => {
+        topLabels[col].style("font-weight", "bold");
+        leftLabels[row].style("font-weight", "bold");
+      }).on("mouseout", () => {
+        topLabels[col].style("font-weight", null);
+        leftLabels[row].style("font-weight", null);
+      });
 
       if (row === col) {
         // Diagonal: histogram of this variable
         const valid = validFor(data, rowVar);
-        const vals = valid.map((d) => d[rowVar]);
         const xSc = d3.scaleLinear().domain(extents[rowVar]).nice().range([pad, cellSize - pad]);
         const binner = d3.bin().value((d) => d[rowVar]).domain(xSc.domain()).thresholds(10);
-        const bins = binner(valid);
-        const yMax = d3.max(bins, (b) => b.length);
+        const allBins = binner(valid);
+        const yMax = d3.max(allBins, (b) => b.length);
         const ySc = d3.scaleLinear().domain([0, yMax]).range([cellSize - pad, pad]);
 
-        cell.selectAll("rect.diag-bin")
-          .data(bins)
-          .join("rect")
-          .attr("class", "diag-bin")
-          .attr("x", (b) => xSc(b.x0))
-          .attr("y", (b) => ySc(b.length))
-          .attr("width", (b) => Math.max(0, xSc(b.x1) - xSc(b.x0) - 0.5))
-          .attr("height", (b) => (cellSize - pad) - ySc(b.length))
-          .attr("fill", "#4e79a7").attr("opacity", 0.7);
+        if (colorByRegion) {
+          // Stacked: accumulate bin counts per region so bars sit on top of each other
+          const cumulative = new Array(allBins.length).fill(0);
+          REGIONS.forEach((region) => {
+            const regionBins = binner(valid.filter((d) => d.region === region));
+            regionBins.forEach((b, i) => {
+              if (b.length === 0) return;
+              const bottom = cumulative[i];
+              const top = bottom + b.length;
+              cell.append("rect")
+                .attr("x", xSc(b.x0))
+                .attr("y", ySc(top))
+                .attr("width", Math.max(0, xSc(b.x1) - xSc(b.x0) - 0.5))
+                .attr("height", ySc(bottom) - ySc(top))
+                .attr("fill", regionColor(region)).attr("opacity", 0.85);
+              cumulative[i] = top;
+            });
+          });
+        } else {
+          cell.selectAll("rect.diag-bin")
+            .data(allBins)
+            .join("rect")
+            .attr("class", "diag-bin")
+            .attr("x", (b) => xSc(b.x0))
+            .attr("y", (b) => ySc(b.length))
+            .attr("width", (b) => Math.max(0, xSc(b.x1) - xSc(b.x0) - 0.5))
+            .attr("height", (b) => (cellSize - pad) - ySc(b.length))
+            .attr("fill", "#4e79a7").attr("opacity", 0.7);
+        }
 
       } else if (row > col) {
         // Below diagonal: scatterplot
@@ -146,7 +190,7 @@ export function scatterplotMatrix(data, {
           .attr("x", cellSize / 2).attr("y", cellSize / 2 + 5)
           .attr("text-anchor", "middle")
           .attr("dominant-baseline", "middle")
-          .style("font-size", `${10 + absR * 8}px`)
+          .style("font-size", `${13 + absR * 9}px`)
           .style("font-weight", absR > 0.6 ? "bold" : "normal")
           .attr("fill", rColor)
           .text(isNaN(r) ? "—" : d3.format(".2f")(r));
@@ -159,7 +203,7 @@ export function scatterplotMatrix(data, {
         cell.append("g")
           .attr("transform", `translate(0,${cellSize})`)
           .call(d3.axisBottom(xSc).ticks(3).tickSize(3).tickFormat(d3.format(".2s")))
-          .selectAll("text").style("font-size", "8px");
+          .selectAll("text").style("font-size", "11px");
         cell.select(".domain").remove();
       }
       if (col === 0) {
@@ -169,22 +213,25 @@ export function scatterplotMatrix(data, {
           .range([cellSize - pad, pad]);
         cell.append("g")
           .call(d3.axisLeft(ySc).ticks(3).tickSize(3).tickFormat(d3.format(".2s")))
-          .selectAll("text").style("font-size", "8px");
+          .selectAll("text").style("font-size", "11px");
         cell.select(".domain").remove();
       }
     });
 
-    // Variable labels on diagonal
-    const diagCell = root.select(`.r${row}c${row}`);
-    diagCell.append("text")
-      .attr("x", cellSize / 2).attr("y", 14)
-      .attr("text-anchor", "middle")
-      .style("font-size", "10px")
-      .style("font-weight", "bold")
-      .attr("fill", "currentColor")
-      .text(NUMERIC_LABELS[variables[row]] || variables[row]);
   });
 
+
+  // Region legend
+  if (colorByRegion) {
+    const lx = totalSize + labelH * 2 + 8;
+    const lg = svg.append("g").attr("transform", `translate(${lx},${labelH})`);
+    REGIONS.forEach((r, i) => {
+      lg.append("circle").attr("cx", 6).attr("cy", i * 20 + 6).attr("r", 5)
+        .attr("fill", regionColor(r)).attr("opacity", 0.8);
+      lg.append("text").attr("x", 16).attr("y", i * 20 + 10)
+        .attr("fill", "currentColor").style("font-size", "11px").text(r);
+    });
+  }
 
   return svg.node();
 }

--- a/d3/src/style.css
+++ b/d3/src/style.css
@@ -52,10 +52,20 @@ svg {
   overflow: visible;
 }
 
+/* SPLOM cell backgrounds — CSS-driven so they react to live theme changes */
+.splom-cell-diag { fill: #f0f4f8; }
+.splom-cell-off  { fill: #fafafa; }
+
+@media (prefers-color-scheme: dark) {
+  .splom-cell-diag { fill: #1a2433; }
+  .splom-cell-off  { fill: #111820; }
+}
+
 .chart-x-label,
 .chart-y-label {
   font-size: 12px;
-  fill: var(--theme-foreground-muted, #666);
+  fill: currentColor;
+  opacity: 0.75;
 }
 
 .axis text {


### PR DESCRIPTION
Dark/light mode:
- Warning boxes adapt via prefers-color-scheme media query
- All SVG axis text/lines use currentColor (ticks, labels, domains)
- Scatterplot grid lines use currentColor at 10% opacity
- Boxplot whiskers, box borders, outlier strokes use currentColor
- SPLOM cell backgrounds CSS-driven (react to live theme changes)
- All legend and annotation text uses currentColor throughout

SPLOM:
- Cell size increased to 170px, labelH 60px for readability
- Outer axis labels restored (top/left), no rotation; 11px consistent
- Diagonal variable name labels removed (redundant with outer labels)
- Hover bolds the relevant column/row axis labels only (subtle)
- Diagonal histograms split by region when colorByRegion (stacked)
- Region legend added when colorByRegion is true

Histogram:
- colorByRegion support: stacked bars per region with legend

Parallel coordinates:
- Removed raise() on hover (was causing lingering highlight bug)
- Region legend centered below chart; bottom margin accounts for it

Scatterplot / Boxplot:
- Legend text fill fixed for dark mode